### PR TITLE
feat: add basic status effect system

### DIFF
--- a/app/src/main/java/com/obliviongatestudio/akthosidle/domain/model/StatusEffect.java
+++ b/app/src/main/java/com/obliviongatestudio/akthosidle/domain/model/StatusEffect.java
@@ -1,0 +1,35 @@
+package com.obliviongatestudio.akthosidle.domain.model;
+
+/**
+ * Basic runtime status effect used by the {@link com.obliviongatestudio.akthosidle.engine.CombatEngine}.
+ * The goal of this lightweight class is to provide just enough structure to
+ * model common RPG effects (damage over time, heal over time, stun and slow)
+ * without pulling in a full component system.
+ */
+public class StatusEffect {
+    public enum Type { DOT, HOT, STUN, SLOW }
+
+    public final Type type;
+    /** Remaining duration in seconds. */
+    public double remaining;
+    /**
+     * Generic magnitude value. For DoT/HoT this is applied per tick (1s).
+     * For SLOW this represents a fractional slowdown (0.25 = +25% interval).
+     */
+    public double value;
+    /** Internal accumulator for 1s ticks on DoT/HoT. */
+    public double tickAcc;
+
+    public StatusEffect(Type type, double durationSec, double value) {
+        this.type = type;
+        this.remaining = durationSec;
+        this.value = value;
+        this.tickAcc = 0.0;
+    }
+
+    public StatusEffect copy() {
+        StatusEffect c = new StatusEffect(this.type, this.remaining, this.value);
+        c.tickAcc = this.tickAcc;
+        return c;
+    }
+}

--- a/app/src/main/java/com/obliviongatestudio/akthosidle/engine/CombatEngine.java
+++ b/app/src/main/java/com/obliviongatestudio/akthosidle/engine/CombatEngine.java
@@ -14,6 +14,7 @@ import com.obliviongatestudio.akthosidle.domain.model.Monster;
 import com.obliviongatestudio.akthosidle.domain.model.PlayerCharacter;
 import com.obliviongatestudio.akthosidle.domain.model.SkillId;
 import com.obliviongatestudio.akthosidle.domain.model.Stats;
+import com.obliviongatestudio.akthosidle.domain.model.StatusEffect;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,9 +39,9 @@ public class CombatEngine {
         public float playerAttackInterval;
         public float monsterAttackInterval;
 
-        // 🔥 Burn status (on monster)
-        public int burnStacksOnMonster;
-        public float burnRemainingSec;
+        /** Active status effects for UI display */
+        public List<StatusEffect> playerEffects = new ArrayList<>();
+        public List<StatusEffect> monsterEffects = new ArrayList<>();
 
         public boolean running;
     }
@@ -72,16 +73,13 @@ public class CombatEngine {
     // cache current intervals (seconds) for progress calculation
     private double pAtkItv = 2.5, mAtkItv = 2.5;
 
-    // 🔥 Burn constants
+    // Example burn effect constants (player applies to monster)
     private static final double BURN_APPLY_CHANCE = 0.25;
-    private static final int    BURN_MAX_STACKS   = 5;
     private static final double BURN_DURATION_SEC = 5.0;
-    private static final int    BURN_DMG_PER_TICK_PER_STACK = 2;
+    private static final int    BURN_DMG_PER_TICK = 2;
 
-    // Burn runtime (monster)
-    private int burnStacks = 0;
-    private double burnRemainSec = 0.0;
-    private double burnTickAcc = 0.0;
+    private final List<StatusEffect> playerEffects = new ArrayList<>();
+    private final List<StatusEffect> monsterEffects = new ArrayList<>();
 
     public CombatEngine(GameRepository repo) {
         this.repo = repo;
@@ -115,8 +113,10 @@ public class CombatEngine {
         s.playerAttackInterval = 0f;
         s.monsterAttackInterval = 0f;
 
-        burnStacks = 0; burnRemainSec = 0.0; burnTickAcc = 0.0;
-        s.burnStacksOnMonster = 0; s.burnRemainingSec = 0f;
+        playerEffects.clear();
+        monsterEffects.clear();
+        s.playerEffects = new ArrayList<>();
+        s.monsterEffects = new ArrayList<>();
 
         s.running = true;
         state.setValue(s);
@@ -161,11 +161,16 @@ public class CombatEngine {
         double deltaSec = Math.max(0, (now - lastTickMs) / 1000.0);
         lastTickMs = now;
 
-        pAtkItv = Math.max(0.6, 2.5 - clamp01(pStats.speed) * 2.5);
-        mAtkItv = Math.max(0.6, 2.5 - clamp01(mStats.speed) * 2.5);
+        double pSlowMult = 1.0 + totalSlow(playerEffects);
+        double mSlowMult = 1.0 + totalSlow(monsterEffects);
+        boolean pStunned = hasStun(playerEffects);
+        boolean mStunned = hasStun(monsterEffects);
 
-        pTimer += deltaSec;
-        mTimer += deltaSec;
+        pAtkItv = Math.max(0.6, 2.5 - clamp01(pStats.speed) * 2.5) * pSlowMult;
+        mAtkItv = Math.max(0.6, 2.5 - clamp01(mStats.speed) * 2.5) * mSlowMult;
+
+        if (!pStunned) pTimer += deltaSec; else pTimer = 0;
+        if (!mStunned) mTimer += deltaSec; else mTimer = 0;
 
         while (pTimer >= pAtkItv && s.monsterHp > 0) {
             pTimer -= pAtkItv;
@@ -173,24 +178,15 @@ public class CombatEngine {
                     clamp01(pStats.critChance), Math.max(1.0, pStats.critMultiplier));
             s.monsterHp = Math.max(0, s.monsterHp - res.dmg);
             logLine("You hit " + s.monsterName + " for " + res.dmg + (res.crit ? " (CRIT!)" : ""));
+            if (rng.nextDouble() < BURN_APPLY_CHANCE) {
+                monsterEffects.add(new StatusEffect(StatusEffect.Type.DOT, BURN_DURATION_SEC, BURN_DMG_PER_TICK));
+                logLine("Burn applied");
+            }
         }
 
-        // 🔥 Burn tick
-        if (burnStacks > 0 && s.monsterHp > 0) {
-            burnRemainSec = Math.max(0.0, burnRemainSec - deltaSec);
-            burnTickAcc += deltaSec;
-            while (burnTickAcc >= 1.0 && burnRemainSec > 0.0 && s.monsterHp > 0) {
-                int burnDmg = burnStacks * BURN_DMG_PER_TICK_PER_STACK;
-                s.monsterHp = Math.max(0, s.monsterHp - burnDmg);
-                burnTickAcc -= 1.0;
-                logLine("Burn tick: -" + burnDmg + " HP (" + burnStacks + " stacks)");
-            }
-            if (burnRemainSec == 0.0) {
-                burnStacks = 0;
-                burnTickAcc = 0.0;
-                logLine("Burn expired");
-            }
-        }
+        // update ongoing effects
+        updateEffects(monsterEffects, false, deltaSec, s);
+        updateEffects(playerEffects, true, deltaSec, s);
 
         while (mTimer >= mAtkItv && s.playerHp > 0) {
             mTimer -= mAtkItv;
@@ -222,8 +218,8 @@ public class CombatEngine {
             s.monsterAttackProgress = (float) Math.min(1.0, mTimer / mAtkItv);
             s.playerAttackInterval = (float) pAtkItv;
             s.monsterAttackInterval = (float) mAtkItv;
-            s.burnStacksOnMonster = burnStacks;
-            s.burnRemainingSec = (float) burnRemainSec;
+            s.playerEffects = copyEffects(playerEffects);
+            s.monsterEffects = copyEffects(monsterEffects);
             state.setValue(s);
             return;
         }
@@ -233,8 +229,8 @@ public class CombatEngine {
         s.playerAttackInterval = (float) pAtkItv;
         s.monsterAttackInterval = (float) mAtkItv;
 
-        s.burnStacksOnMonster = burnStacks;
-        s.burnRemainingSec = (float) burnRemainSec;
+        s.playerEffects = copyEffects(playerEffects);
+        s.monsterEffects = copyEffects(monsterEffects);
 
         state.setValue(s);
         loop();
@@ -284,6 +280,55 @@ public class CombatEngine {
         }
 
         repo.save();
+    }
+
+    private void updateEffects(List<StatusEffect> list, boolean onPlayer, double deltaSec, BattleState s) {
+        for (int i = list.size() - 1; i >= 0; i--) {
+            StatusEffect e = list.get(i);
+            e.remaining -= deltaSec;
+            if (e.type == StatusEffect.Type.DOT || e.type == StatusEffect.Type.HOT) {
+                e.tickAcc += deltaSec;
+                while (e.tickAcc >= 1.0 && e.remaining > 0) {
+                    int amt = (int) Math.round(e.value);
+                    if (e.type == StatusEffect.Type.DOT) {
+                        if (onPlayer) {
+                            s.playerHp = Math.max(0, s.playerHp - amt);
+                        } else {
+                            s.monsterHp = Math.max(0, s.monsterHp - amt);
+                        }
+                        logLine((onPlayer ? "You" : s.monsterName) + " suffer " + amt + " damage");
+                    } else {
+                        if (onPlayer) {
+                            s.playerHp = Math.min(s.playerMaxHp, s.playerHp + amt);
+                        } else {
+                            s.monsterHp = Math.min(s.monsterMaxHp, s.monsterHp + amt);
+                        }
+                        logLine((onPlayer ? "You" : s.monsterName) + " heal " + amt);
+                    }
+                    e.tickAcc -= 1.0;
+                }
+            }
+            if (e.remaining <= 0) {
+                list.remove(i);
+            }
+        }
+    }
+
+    private double totalSlow(List<StatusEffect> list) {
+        double t = 0.0;
+        for (StatusEffect e : list) if (e.type == StatusEffect.Type.SLOW) t += e.value;
+        return t;
+    }
+
+    private boolean hasStun(List<StatusEffect> list) {
+        for (StatusEffect e : list) if (e.type == StatusEffect.Type.STUN) return true;
+        return false;
+    }
+
+    private List<StatusEffect> copyEffects(List<StatusEffect> src) {
+        List<StatusEffect> out = new ArrayList<>();
+        for (StatusEffect e : src) out.add(e.copy());
+        return out;
     }
 
     private static double clamp01(double v) {


### PR DESCRIPTION
## Summary
- introduce `StatusEffect` model for DoT/HoT, stun and slow effects
- extend `CombatEngine` to handle status effects, including burn as DoT and attack speed modifiers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b34033e040832484fe4331bd3f6394