### PR TITLE
feat: add elemental system and job action loop

### DIFF
--- a/app/src/main/java/com/obliviongatestudio/akthosidle/domain/model/Element.java
+++ b/app/src/main/java/com/obliviongatestudio/akthosidle/domain/model/Element.java
@@ -1,0 +1,12 @@
+package com.obliviongatestudio.akthosidle.domain.model;
+
+/**
+ * Basic elemental types for combat interactions.
+ */
+public enum Element {
+    NEUTRAL,
+    FIRE,
+    WATER,
+    AIR,
+    EARTH
+}

--- a/app/src/main/java/com/obliviongatestudio/akthosidle/domain/model/Monster.java
+++ b/app/src/main/java/com/obliviongatestudio/akthosidle/domain/model/Monster.java
@@ -2,11 +2,15 @@ package com.obliviongatestudio.akthosidle.domain.model;
 
 import java.util.List;
 
+import com.obliviongatestudio.akthosidle.domain.model.Element;
+
 /** Game monster definition parsed from JSON. */
 public class Monster {
     public String id;
     public String name;
     public Stats stats;          // Repo ensures default if null.
+    /** Elemental affinity used for weakness/strength calculations. */
+    public Element element = Element.NEUTRAL;
 
     public List<Drop> drops;     // Optional loot table
 
@@ -44,6 +48,12 @@ public class Monster {
         normalize();
     }
 
+    public Monster(String id, String name, Stats stats, List<Drop> drops,
+                   int exp, int silverReward, int slayerReward, Element element) {
+        this(id, name, stats, drops, exp, silverReward, slayerReward);
+        this.element = element != null ? element : Element.NEUTRAL;
+    }
+
     /** Back-compat ctor that used to pass expReward & goldReward. */
     public Monster(String id, String name, Stats stats, List<Drop> drops,
                    int expRewardLegacy, int goldRewardLegacy) {
@@ -58,6 +68,7 @@ public class Monster {
     public void normalize() {
         if (name == null) name = id;
         if (stats == null) stats = new Stats();
+        if (element == null) element = Element.NEUTRAL;
 
         // If legacy field has value but new field doesn't, adopt it.
         if (exp <= 0 && expReward > 0) exp = expReward;

--- a/app/src/main/java/com/obliviongatestudio/akthosidle/domain/model/PlayerCharacter.java
+++ b/app/src/main/java/com/obliviongatestudio/akthosidle/domain/model/PlayerCharacter.java
@@ -6,6 +6,8 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.obliviongatestudio.akthosidle.domain.model.Element;
+
 public class PlayerCharacter {
     // --- persisted fields ---
 
@@ -21,6 +23,8 @@ public class PlayerCharacter {
 
     public Map<String, Long> currencies = new HashMap<>();
     public Stats base = new Stats(12, 6, 0.0, 100, 0.05, 1.5);
+    /** Elemental affinity for the player. */
+    public Element element = Element.NEUTRAL;
     public int getCurrentHp;
 
     public int getCurrentHp() {

--- a/app/src/main/java/com/obliviongatestudio/akthosidle/domain/model/StatusEffect.java
+++ b/app/src/main/java/com/obliviongatestudio/akthosidle/domain/model/StatusEffect.java
@@ -1,0 +1,35 @@
+package com.obliviongatestudio.akthosidle.domain.model;
+
+/**
+ * Basic runtime status effect used by the {@link com.obliviongatestudio.akthosidle.engine.CombatEngine}.
+ * The goal of this lightweight class is to provide just enough structure to
+ * model common RPG effects (damage over time, heal over time, stun and slow)
+ * without pulling in a full component system.
+ */
+public class StatusEffect {
+    public enum Type { DOT, HOT, STUN, SLOW }
+
+    public final Type type;
+    /** Remaining duration in seconds. */
+    public double remaining;
+    /**
+     * Generic magnitude value. For DoT/HoT this is applied per tick (1s).
+     * For SLOW this represents a fractional slowdown (0.25 = +25% interval).
+     */
+    public double value;
+    /** Internal accumulator for 1s ticks on DoT/HoT. */
+    public double tickAcc;
+
+    public StatusEffect(Type type, double durationSec, double value) {
+        this.type = type;
+        this.remaining = durationSec;
+        this.value = value;
+        this.tickAcc = 0.0;
+    }
+
+    public StatusEffect copy() {
+        StatusEffect c = new StatusEffect(this.type, this.remaining, this.value);
+        c.tickAcc = this.tickAcc;
+        return c;
+    }
+}

--- a/app/src/main/java/com/obliviongatestudio/akthosidle/domain/services/TickService.java
+++ b/app/src/main/java/com/obliviongatestudio/akthosidle/domain/services/TickService.java
@@ -2,19 +2,14 @@ package com.obliviongatestudio.akthosidle.domain.services;
 
 import com.obliviongatestudio.akthosidle.data.dtos.Snapshot;
 import com.obliviongatestudio.akthosidle.domain.model.Job;
+import com.obliviongatestudio.akthosidle.engine.JobEngine;
 
 public class TickService {
     public Snapshot applyCatchUp(Snapshot s, long nowMs) {
         long delta = Math.max(0, nowMs - s.timestampMs);
         if (s.jobs != null) {
             for (Job j : s.jobs) {
-                long total = j.progressMs + delta;
-                if (j.intervalMs > 0) {
-                    long ticks = total / j.intervalMs;
-                    j.progressMs = total % j.intervalMs;
-                    j.accumulatedXp += j.xpPerTick * ticks;
-                    j.accumulatedCurrency += j.currencyPerTick * ticks;
-                }
+                JobEngine.applyProgress(j, delta);
             }
         }
         s.timestampMs = nowMs;

--- a/app/src/main/java/com/obliviongatestudio/akthosidle/engine/CombatEngine.java
+++ b/app/src/main/java/com/obliviongatestudio/akthosidle/engine/CombatEngine.java
@@ -14,6 +14,8 @@ import com.obliviongatestudio.akthosidle.domain.model.Monster;
 import com.obliviongatestudio.akthosidle.domain.model.PlayerCharacter;
 import com.obliviongatestudio.akthosidle.domain.model.SkillId;
 import com.obliviongatestudio.akthosidle.domain.model.Stats;
+import com.obliviongatestudio.akthosidle.domain.model.StatusEffect;
+import com.obliviongatestudio.akthosidle.domain.model.Element;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,9 +40,9 @@ public class CombatEngine {
         public float playerAttackInterval;
         public float monsterAttackInterval;
 
-        // 🔥 Burn status (on monster)
-        public int burnStacksOnMonster;
-        public float burnRemainingSec;
+        /** Active status effects for UI display */
+        public List<StatusEffect> playerEffects = new ArrayList<>();
+        public List<StatusEffect> monsterEffects = new ArrayList<>();
 
         public boolean running;
     }
@@ -68,20 +70,18 @@ public class CombatEngine {
     private Stats pStats, mStats;
     private Monster monster;
     private PlayerCharacter pc;
+    private Element pElement = Element.NEUTRAL, mElement = Element.NEUTRAL;
 
     // cache current intervals (seconds) for progress calculation
     private double pAtkItv = 2.5, mAtkItv = 2.5;
 
-    // 🔥 Burn constants
+    // Example burn effect constants (player applies to monster)
     private static final double BURN_APPLY_CHANCE = 0.25;
-    private static final int    BURN_MAX_STACKS   = 5;
     private static final double BURN_DURATION_SEC = 5.0;
-    private static final int    BURN_DMG_PER_TICK_PER_STACK = 2;
+    private static final int    BURN_DMG_PER_TICK = 2;
 
-    // Burn runtime (monster)
-    private int burnStacks = 0;
-    private double burnRemainSec = 0.0;
-    private double burnTickAcc = 0.0;
+    private final List<StatusEffect> playerEffects = new ArrayList<>();
+    private final List<StatusEffect> monsterEffects = new ArrayList<>();
 
     public CombatEngine(GameRepository repo) {
         this.repo = repo;
@@ -99,6 +99,8 @@ public class CombatEngine {
 
         this.pStats = (pc != null) ? pc.totalStats(repo.gearStats(pc)) : new Stats();
         this.mStats = (monster.stats != null) ? monster.stats : new Stats();
+        this.pElement = (pc != null && pc.element != null) ? pc.element : Element.NEUTRAL;
+        this.mElement = (monster.element != null) ? monster.element : Element.NEUTRAL;
 
         BattleState s = new BattleState();
         s.monsterId = monsterId;
@@ -115,8 +117,10 @@ public class CombatEngine {
         s.playerAttackInterval = 0f;
         s.monsterAttackInterval = 0f;
 
-        burnStacks = 0; burnRemainSec = 0.0; burnTickAcc = 0.0;
-        s.burnStacksOnMonster = 0; s.burnRemainingSec = 0f;
+        playerEffects.clear();
+        monsterEffects.clear();
+        s.playerEffects = new ArrayList<>();
+        s.monsterEffects = new ArrayList<>();
 
         s.running = true;
         state.setValue(s);
@@ -161,43 +165,41 @@ public class CombatEngine {
         double deltaSec = Math.max(0, (now - lastTickMs) / 1000.0);
         lastTickMs = now;
 
-        pAtkItv = Math.max(0.6, 2.5 - clamp01(pStats.speed) * 2.5);
-        mAtkItv = Math.max(0.6, 2.5 - clamp01(mStats.speed) * 2.5);
+        double pSlowMult = 1.0 + totalSlow(playerEffects);
+        double mSlowMult = 1.0 + totalSlow(monsterEffects);
+        boolean pStunned = hasStun(playerEffects);
+        boolean mStunned = hasStun(monsterEffects);
 
-        pTimer += deltaSec;
-        mTimer += deltaSec;
+        pAtkItv = Math.max(0.6, 2.5 - clamp01(pStats.speed) * 2.5) * pSlowMult;
+        mAtkItv = Math.max(0.6, 2.5 - clamp01(mStats.speed) * 2.5) * mSlowMult;
+
+        if (!pStunned) pTimer += deltaSec; else pTimer = 0;
+        if (!mStunned) mTimer += deltaSec; else mTimer = 0;
 
         while (pTimer >= pAtkItv && s.monsterHp > 0) {
             pTimer -= pAtkItv;
             DamageResult res = damageRollEx(pStats.attack, mStats.defense,
                     clamp01(pStats.critChance), Math.max(1.0, pStats.critMultiplier));
-            s.monsterHp = Math.max(0, s.monsterHp - res.dmg);
-            logLine("You hit " + s.monsterName + " for " + res.dmg + (res.crit ? " (CRIT!)" : ""));
+            int finalDmg = CombatMath.applyElementMod(res.dmg, ElementalSystem.modifier(pElement, mElement));
+            s.monsterHp = Math.max(0, s.monsterHp - finalDmg);
+            logLine("You hit " + s.monsterName + " for " + finalDmg + (res.crit ? " (CRIT!)" : ""));
+            if (rng.nextDouble() < BURN_APPLY_CHANCE) {
+                monsterEffects.add(new StatusEffect(StatusEffect.Type.DOT, BURN_DURATION_SEC, BURN_DMG_PER_TICK));
+                logLine("Burn applied");
+            }
         }
 
-        // 🔥 Burn tick
-        if (burnStacks > 0 && s.monsterHp > 0) {
-            burnRemainSec = Math.max(0.0, burnRemainSec - deltaSec);
-            burnTickAcc += deltaSec;
-            while (burnTickAcc >= 1.0 && burnRemainSec > 0.0 && s.monsterHp > 0) {
-                int burnDmg = burnStacks * BURN_DMG_PER_TICK_PER_STACK;
-                s.monsterHp = Math.max(0, s.monsterHp - burnDmg);
-                burnTickAcc -= 1.0;
-                logLine("Burn tick: -" + burnDmg + " HP (" + burnStacks + " stacks)");
-            }
-            if (burnRemainSec == 0.0) {
-                burnStacks = 0;
-                burnTickAcc = 0.0;
-                logLine("Burn expired");
-            }
-        }
+        // update ongoing effects
+        updateEffects(monsterEffects, false, deltaSec, s);
+        updateEffects(playerEffects, true, deltaSec, s);
 
         while (mTimer >= mAtkItv && s.playerHp > 0) {
             mTimer -= mAtkItv;
             DamageResult res = damageRollEx(mStats.attack, pStats.defense,
                     clamp01(mStats.critChance), Math.max(1.0, mStats.critMultiplier));
-            s.playerHp = Math.max(0, s.playerHp - res.dmg);
-            logLine(s.monsterName + " hits you for " + res.dmg + (res.crit ? " (CRIT!)" : ""));
+            int finalDmg = CombatMath.applyElementMod(res.dmg, ElementalSystem.modifier(mElement, pElement));
+            s.playerHp = Math.max(0, s.playerHp - finalDmg);
+            logLine(s.monsterName + " hits you for " + finalDmg + (res.crit ? " (CRIT!)" : ""));
         }
 
         // defeat/victory
@@ -222,8 +224,8 @@ public class CombatEngine {
             s.monsterAttackProgress = (float) Math.min(1.0, mTimer / mAtkItv);
             s.playerAttackInterval = (float) pAtkItv;
             s.monsterAttackInterval = (float) mAtkItv;
-            s.burnStacksOnMonster = burnStacks;
-            s.burnRemainingSec = (float) burnRemainSec;
+            s.playerEffects = copyEffects(playerEffects);
+            s.monsterEffects = copyEffects(monsterEffects);
             state.setValue(s);
             return;
         }
@@ -233,8 +235,8 @@ public class CombatEngine {
         s.playerAttackInterval = (float) pAtkItv;
         s.monsterAttackInterval = (float) mAtkItv;
 
-        s.burnStacksOnMonster = burnStacks;
-        s.burnRemainingSec = (float) burnRemainSec;
+        s.playerEffects = copyEffects(playerEffects);
+        s.monsterEffects = copyEffects(monsterEffects);
 
         state.setValue(s);
         loop();
@@ -284,6 +286,55 @@ public class CombatEngine {
         }
 
         repo.save();
+    }
+
+    private void updateEffects(List<StatusEffect> list, boolean onPlayer, double deltaSec, BattleState s) {
+        for (int i = list.size() - 1; i >= 0; i--) {
+            StatusEffect e = list.get(i);
+            e.remaining -= deltaSec;
+            if (e.type == StatusEffect.Type.DOT || e.type == StatusEffect.Type.HOT) {
+                e.tickAcc += deltaSec;
+                while (e.tickAcc >= 1.0 && e.remaining > 0) {
+                    int amt = (int) Math.round(e.value);
+                    if (e.type == StatusEffect.Type.DOT) {
+                        if (onPlayer) {
+                            s.playerHp = Math.max(0, s.playerHp - amt);
+                        } else {
+                            s.monsterHp = Math.max(0, s.monsterHp - amt);
+                        }
+                        logLine((onPlayer ? "You" : s.monsterName) + " suffer " + amt + " damage");
+                    } else {
+                        if (onPlayer) {
+                            s.playerHp = Math.min(s.playerMaxHp, s.playerHp + amt);
+                        } else {
+                            s.monsterHp = Math.min(s.monsterMaxHp, s.monsterHp + amt);
+                        }
+                        logLine((onPlayer ? "You" : s.monsterName) + " heal " + amt);
+                    }
+                    e.tickAcc -= 1.0;
+                }
+            }
+            if (e.remaining <= 0) {
+                list.remove(i);
+            }
+        }
+    }
+
+    private double totalSlow(List<StatusEffect> list) {
+        double t = 0.0;
+        for (StatusEffect e : list) if (e.type == StatusEffect.Type.SLOW) t += e.value;
+        return t;
+    }
+
+    private boolean hasStun(List<StatusEffect> list) {
+        for (StatusEffect e : list) if (e.type == StatusEffect.Type.STUN) return true;
+        return false;
+    }
+
+    private List<StatusEffect> copyEffects(List<StatusEffect> src) {
+        List<StatusEffect> out = new ArrayList<>();
+        for (StatusEffect e : src) out.add(e.copy());
+        return out;
     }
 
     private static double clamp01(double v) {

--- a/app/src/main/java/com/obliviongatestudio/akthosidle/engine/ElementalSystem.java
+++ b/app/src/main/java/com/obliviongatestudio/akthosidle/engine/ElementalSystem.java
@@ -1,0 +1,45 @@
+package com.obliviongatestudio.akthosidle.engine;
+
+import com.obliviongatestudio.akthosidle.domain.model.Element;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Defines elemental strengths and weaknesses.
+ */
+public final class ElementalSystem {
+    private static final Map<Element, Map<Element, Double>> MATRIX = new EnumMap<>(Element.class);
+    static {
+        for (Element e : Element.values()) {
+            MATRIX.put(e, new EnumMap<>(Element.class));
+        }
+        // Strength/weakness cycle
+        set(Element.FIRE,  Element.EARTH, 1.2);
+        set(Element.FIRE,  Element.WATER, 0.8);
+
+        set(Element.WATER, Element.FIRE,  1.2);
+        set(Element.WATER, Element.AIR,   0.8);
+
+        set(Element.AIR,   Element.WATER, 1.2);
+        set(Element.AIR,   Element.EARTH, 0.8);
+
+        set(Element.EARTH, Element.AIR,   1.2);
+        set(Element.EARTH, Element.FIRE,  0.8);
+    }
+
+    private static void set(Element atk, Element def, double mod) {
+        MATRIX.get(atk).put(def, mod);
+    }
+
+    private ElementalSystem() {}
+
+    /** Returns elemental modifier (1.0 if no relation). */
+    public static double modifier(Element atk, Element def) {
+        if (atk == null || def == null) return 1.0;
+        Map<Element, Double> row = MATRIX.get(atk);
+        if (row == null) return 1.0;
+        Double v = row.get(def);
+        return v != null ? v : 1.0;
+    }
+}

--- a/app/src/main/java/com/obliviongatestudio/akthosidle/engine/JobEngine.java
+++ b/app/src/main/java/com/obliviongatestudio/akthosidle/engine/JobEngine.java
@@ -1,0 +1,59 @@
+package com.obliviongatestudio.akthosidle.engine;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+
+import androidx.annotation.Nullable;
+
+import com.obliviongatestudio.akthosidle.domain.model.Job;
+
+/**
+ * Lightweight loop that advances a Job in real-time and accumulates its rewards.
+ */
+public class JobEngine {
+    @Nullable private Job current;
+    private final Handler handler = new Handler(Looper.getMainLooper());
+    private long lastTick;
+    private boolean running;
+
+    /** Begin looping the given job. */
+    public void start(Job job) {
+        current = job;
+        lastTick = SystemClock.uptimeMillis();
+        running = true;
+        loop();
+    }
+
+    /** Stop the loop. */
+    public void stop() {
+        running = false;
+        handler.removeCallbacksAndMessages(null);
+        current = null;
+    }
+
+    private void loop() {
+        if (!running) return;
+        handler.postDelayed(this::tick, 50);
+    }
+
+    private void tick() {
+        if (!running || current == null) return;
+        long now = SystemClock.uptimeMillis();
+        long delta = now - lastTick;
+        lastTick = now;
+        applyProgress(current, delta);
+        loop();
+    }
+
+    /** Core progress logic reused by TickService and tests. */
+    public static void applyProgress(Job j, long deltaMs) {
+        long total = j.progressMs + deltaMs;
+        if (j.intervalMs > 0) {
+            long ticks = total / j.intervalMs;
+            j.progressMs = total % j.intervalMs;
+            j.accumulatedXp += j.xpPerTick * ticks;
+            j.accumulatedCurrency += j.currencyPerTick * ticks;
+        }
+    }
+}

--- a/app/src/test/java/com/obliviongatestudio/akthosidle/engine/ElementalSystemTest.java
+++ b/app/src/test/java/com/obliviongatestudio/akthosidle/engine/ElementalSystemTest.java
@@ -1,0 +1,17 @@
+package com.obliviongatestudio.akthosidle.engine;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.obliviongatestudio.akthosidle.domain.model.Element;
+
+public class ElementalSystemTest {
+    @Test public void fire_beats_earth() {
+        assertEquals(1.2, ElementalSystem.modifier(Element.FIRE, Element.EARTH), 0.0001);
+    }
+
+    @Test public void water_loses_to_air() {
+        assertEquals(0.8, ElementalSystem.modifier(Element.WATER, Element.AIR), 0.0001);
+    }
+}

--- a/app/src/test/java/com/obliviongatestudio/akthosidle/engine/JobEngineTest.java
+++ b/app/src/test/java/com/obliviongatestudio/akthosidle/engine/JobEngineTest.java
@@ -1,0 +1,20 @@
+package com.obliviongatestudio.akthosidle.engine;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.obliviongatestudio.akthosidle.domain.model.Job;
+
+public class JobEngineTest {
+    @Test public void apply_progress_awards_ticks() {
+        Job j = new Job();
+        j.intervalMs = 1000;
+        j.xpPerTick = 5;
+        j.currencyPerTick = 2;
+        JobEngine.applyProgress(j, 2500);
+        assertEquals(0, j.progressMs);
+        assertEquals(10, j.accumulatedXp);
+        assertEquals(4, j.accumulatedCurrency);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Element` enum and matrix-driven `ElementalSystem`
- use elemental affinities in combat damage calculations
- introduce `JobEngine` and share progress logic with `TickService`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b34033e040832484fe4331bd3f6394